### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
           DEPLOY_TARGET: pages   # astro.config.mjs 側で base/site を切替
         run: npm run build
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- add configure-pages step so main branch pushes deploy to GitHub Pages

## Testing
- `npm ci`
- `npm run build`
- `npm run lint --if-present`
- `npm run typecheck --if-present`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68c38716b6d08326979ca3fc378493d6