### PR TITLE
画像インデックス生成時に件数などをログ出力

### DIFF
--- a/scripts/build-images.mjs
+++ b/scripts/build-images.mjs
@@ -295,7 +295,12 @@ try {
       relatedCount: (r.links && Array.isArray(r.links.related)) ? r.links.related.length : 0,
       sortKey: typeof r.sortKey === 'number' ? r.sortKey : Date.parse(r.createdAt || 0)
     }));
-  fs.writeFileSync(path.join(OUT_ROOT, 'images-index.json'), JSON.stringify(slim), 'utf-8');
+  const outPath = path.join(OUT_ROOT, 'images-index.json');
+  fs.writeFileSync(outPath, JSON.stringify(slim, null, 2) + '\n', 'utf-8');
+  const emptyAlt = slim.filter(x => !x.alt).length;
+  console.log(`images-index: ${slim.length} items → ${outPath}`);
+  console.log(`images-index: empty alt = ${emptyAlt}`);
+  console.log(`images-index: top =`, slim[0]);
 } catch (e) {
   console.warn('Warn: failed to write public/images-index.json', e);
 }


### PR DESCRIPTION
## Summary
- 生成した images-index.json に関する件数・空alt数・先頭要素をコンソールに表示

## Testing
- `npm test`
- `npm run build:images`


------
https://chatgpt.com/codex/tasks/task_e_68c56c3702348326b2f10411415a3af0