### PR TITLE
feat: add warning notice styles

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -85,3 +85,16 @@ body{ margin:0; font-family: system-ui, sans-serif; background:var(--bg); color:
 .panel{ display:none; }
 #tab-images:checked ~ .panels #panel-images{ display:block; }
 #tab-works:checked  ~ .panels #panel-works{  display:block; }
+
+/* warning banner and icon */
+.notice--warn,
+.status-icon--warn{
+  padding:4px 8px;
+  line-height:1.4;
+  background:#333;
+  color:#ffcc33;
+  border-radius:4px;
+}
+
+.notice--warn{ display:block; }
+.status-icon--warn{ display:inline-block; }


### PR DESCRIPTION
## Summary
- 注意UI用に `.notice--warn` と `.status-icon--warn` を追加し、暗色テーマでも読める配色と余白・行高を統一

## Testing
- `npm test`
- sourceStatus=ok / partial / fail の3パターンで表示と文言を確認
- BASE_URL 配下でリンクが壊れていないことを確認
- Lighthouse で color-contrast が基準を満たすことを確認

------
https://chatgpt.com/codex/tasks/task_e_68c5ac6171088326a909c29487263414