### PR TITLE
feat: add build target switching skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
         run: npm test --if-present
 
       # Pages想定で本番ビルドが通るか確認（baseの不備を早期検知）
-      - name: Build (Astro)
-        env:
-          DEPLOY_TARGET: pages   # astro.config.mjs で base/site の分岐に使用
-        run: npm run build
+      - name: Build (staging)
+        run: npm run build:staging
+
+      - name: Build (prod)
+        if: vars.ENABLE_PROD_PIPELINE == 'true'
+        run: npm run build:prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DEPLOY_TARGET: pages
+      PUBLIC_DEPLOY_TARGET: pages
     steps:
       - uses: actions/checkout@v4
 
@@ -27,10 +30,8 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Build (Astro)
-        env:
-          DEPLOY_TARGET: pages   # astro.config.mjs 側で base/site を切替
-        run: npm run build
+      - name: Build (staging)
+        run: npm run build:staging
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -43,9 +44,32 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      DEPLOY_TARGET: pages
+      PUBLIC_DEPLOY_TARGET: pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+
+  build-prod:
+    if: vars.ENABLE_PROD_PIPELINE == 'true'
+    runs-on: ubuntu-latest
+    env:
+      DEPLOY_TARGET: prod
+      PUBLIC_DEPLOY_TARGET: prod
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build (prod)
+        run: npm run build:prod

--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ DEPLOY_TARGET=pages npm run build
 3. 生成された `dist` を任意のホスティングサービスに配置します。`robots.txt` はインデックスを許可します。
 
 `DEPLOY_TARGET` はビルド先の環境を表すための変数で、上記以外の値を指定した場合も独自ドメイン用の挙動になります。
+
+### GitHub Actions の prod ビルド
+
+リポジトリ変数 `ENABLE_PROD_PIPELINE`（Settings → Secrets and variables → Actions → Variables）を `true` にすると、CI でプロダクション向けビルドが有効になります。既定値は `false` です。

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ const isPages = process.env.DEPLOY_TARGET === 'pages';
 
 // https://astro.build/config
 export default defineConfig({
-  site: isPages ? 'https://panappuom.github.io' : 'https://example.com',
+  site: isPages ? 'https://panappuom.github.io' : 'https://example.com', // TODO: production domain
   base: isPages ? '/omochiforts/' : '/',
   vite: {
     plugins: [tailwindcss()]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "tailwindcss": "^4.1.12"
       },
       "devDependencies": {
+        "cross-env": "^10.0.0",
         "fast-glob": "^3.3.3",
         "sharp": "^0.34.3",
         "ulid": "^3.0.1"
@@ -145,6 +146,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.9",
@@ -2572,12 +2580,45 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="
     },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
       "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
       "dependencies": {
         "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/crossws": {
@@ -3296,6 +3337,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jiti": {
       "version": "2.5.1",
@@ -4596,6 +4644,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5051,6 +5109,29 @@
         "@img/sharp-win32-arm64": "0.34.3",
         "@img/sharp-win32-ia32": "0.34.3",
         "@img/sharp-win32-x64": "0.34.3"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shiki": {
@@ -5716,6 +5797,22 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which-pm-runs": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "preview": "astro preview",
     "astro": "astro",
     "test": "echo \"no tests yet\" && exit 0",
-    "build:images": "node scripts/build-images.mjs"
+    "build:images": "node scripts/build-images.mjs",
+    "build:staging": "cross-env DEPLOY_TARGET=pages PUBLIC_DEPLOY_TARGET=pages astro build",
+    "build:prod": "cross-env DEPLOY_TARGET=prod PUBLIC_DEPLOY_TARGET=prod astro build"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.12",
@@ -17,6 +19,7 @@
     "tailwindcss": "^4.1.12"
   },
   "devDependencies": {
+    "cross-env": "^10.0.0",
     "fast-glob": "^3.3.3",
     "sharp": "^0.34.3",
     "ulid": "^3.0.1"


### PR DESCRIPTION
## Summary
- add build scripts for staging/prod with shared env vars
- switch site/base settings based on DEPLOY_TARGET
- adjust CI/CD workflows to conditionally run prod pipeline

## Testing
- `npm run build:staging`
- `npm run build:prod`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6fbecbe608326ba0f7d5d191230f4