### PR TITLE
Add noindex meta for staging builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Build (staging)
         run: npm run build:staging
 
+      - name: Check meta robots (staging)
+        run: |
+          set -e
+          for f in $(find dist -name '*.html'); do
+            grep -q '<meta name="robots" content="noindex, nofollow, noarchive"' "$f"
+            grep -q '<meta name="googlebot" content="noindex, nofollow, noimageindex"' "$f"
+          done
+
       - name: Build (prod)
         if: vars.ENABLE_PROD_PIPELINE == 'true'
         run: npm run build:prod

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ DEPLOY_TARGET=pages npm run build
 
 生成された `dist` を GitHub Pages に配置します。Pages 用ビルドではサイトのベースパスがリポジトリ名になります。`robots.txt` はリポジトリ配下に配置されるためインデックス制御には使えず、常に `Allow: /` を返します。検索エンジンによるインデックスを防ぎたい場合は、ルートドメインの `robots.txt` やページごとの meta タグを設定してください。
 
+> **注意**: `robots.txt` は `https://ホスト/robots.txt` のみがクローラーに認識されます。GitHub Pages のようにサブパスに配置された場合は効果がありません。
+
 ### 独自ドメインに切り替える場合
 
 1. `astro.config.mjs` 内の `https://example.com` を実際のドメインに置き換えます。

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -22,6 +22,12 @@ import "../styles/global.css";
     <title>{title}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="おもち要塞 / OmochiForts" />
+    {import.meta.env.PUBLIC_DEPLOY_TARGET === 'pages' && (
+      <>
+        <meta name="robots" content="noindex, nofollow, noarchive" />
+        <meta name="googlebot" content="noindex, nofollow, noimageindex" />
+      </>
+    )}
 
     <!-- favicons -->
     <!-- 基本 favicon -->


### PR DESCRIPTION
## Summary
- add noindex and googlebot meta tags when deploying to GitHub Pages
- document robots.txt limitation on subpaths
- CI check to verify staging build contains noindex meta

## Testing
- `npm test`
- `npm run build:staging`
- `grep -o '<meta name="robots"[^>]*>' dist/index.html`
- `grep -o '<meta name="googlebot"[^>]*>' dist/index.html`
- `find dist -name '*sitemap*'`
- `npm run build:prod`
- `grep -o '<meta name="robots"[^>]*>' dist/index.html`
- `grep -o '<meta name="googlebot"[^>]*>' dist/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c790a4e4248326ab627cc5bdc95ce1