### PR TITLE
Add canonical link for prod builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Feel free to check [our documentation](https://docs.astro.build) or jump into ou
 | `pages` | `https://panappuom.github.io` | `/omochiforts/` | `User-agent: *\nAllow: /` |
 | (未設定/その他) | `https://example.com` | `/` | `User-agent: *\nAllow: /` |
 
+### canonical と noindex の方針
+
+- `PUBLIC_DEPLOY_TARGET=prod` のビルドでは、各ページの `<head>` に `astro.config.mjs` の `site` 設定とページのパスから生成した `<link rel="canonical">` を挿入します。
+- `PUBLIC_DEPLOY_TARGET=pages` のビルドでは canonical を出力せず、既存の `<meta name="robots" ...>` による noindex 設定で GitHub Pages 側のインデックス制御を行います。
+
 ### GitHub Pages にデプロイする場合
 
 ```bash

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -22,6 +22,9 @@ import "../styles/global.css";
     <title>{title}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="おもち要塞 / OmochiForts" />
+    {import.meta.env.PUBLIC_DEPLOY_TARGET === 'prod' && Astro.site && (
+      <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).toString()} />
+    )}
     {import.meta.env.PUBLIC_DEPLOY_TARGET === 'pages' && (
       <>
         <meta name="robots" content="noindex, nofollow, noarchive" />


### PR DESCRIPTION
## Summary
- inject a canonical `<link>` into the shared layout when `PUBLIC_DEPLOY_TARGET` is `prod`, using the current URL and `Astro.site`
- document the canonical/noindex policy for prod and staging builds in the README

## Testing
- npm run build:prod
- npm run build:staging

------
https://chatgpt.com/codex/tasks/task_e_68c8dd692214832688cd0d03753a2f62