### PR TITLE
Add gitattributes entry for images index

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+public/images-index.json -diff


### PR DESCRIPTION
## Summary
- prevent Git diffs from showing changes to the generated `public/images-index.json`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c91c8190ac83269483ba37f518ab19